### PR TITLE
Fix FSDP for GPTQ-LoRA and Fused Ops

### DIFF
--- a/plugins/accelerated-peft/src/fms_acceleration_peft/autogptq_utils.py
+++ b/plugins/accelerated-peft/src/fms_acceleration_peft/autogptq_utils.py
@@ -23,6 +23,9 @@ from peft import LoraConfig
 from peft.tuners.lora.gptq import QuantLinear as LoraLinearGPTQ
 import torch
 
+# these parameters are to be patched for triton v2
+# consider making a map if patching more kernels
+PATCH_FOR_FSDP_TRITON_V2 = ["qweight", "qzeros"]
 
 def replace_module_peft(self, parent_module, child_name, new_module, old_module):
 
@@ -57,34 +60,47 @@ def create_new_module_peft(
     # if module cannot be found, return None which results in a raise in the call-stack
     return new_module
 
-
 # consider to move this somewhere more general
 def patch_forward_to_view_attributes_before_call(
     old_forward: Callable,
     attribute_names: List[str],
-    torch_dtype,
+    torch_dtype: torch.dtype,
+    submodule_names: str = None,
+    is_method_forward: bool = True,
 ):
     # patch old_forward to view attribtues to torch_dype
     # before call
+        
+    if submodule_names is None:
+        submodule_names = ''
+    if isinstance(submodule_names, str):
+        submodule_names = [submodule_names]
 
     def _forward(self, *args, **kwargs):
-        # perform a view on all these attributes
-        for attr_name in attribute_names:
 
-            # the view should be a passthrough
-            # if attr.dtype == torch_dtype
-            attr = getattr(self, attr_name)
+        for sub_name in submodule_names:
+            mod = self.get_submodule(sub_name)
 
-            # perform view
-            attr = attr.view(torch_dtype)
+            # perform a view on all these attributes
+            for attr_name in attribute_names:
 
-            try:
-                setattr(self, attr_name, attr)
-            except TypeError:
-                # this means already have attr_name as a parameter, then
-                # just assign this way
-                self.__dict__[attr_name] = attr
+                # the view should be a passthrough
+                # if attr.dtype == torch_dtype
+                attr = getattr(mod, attr_name)
 
-        return old_forward(*args, **kwargs)
+                # perform view
+                attr = attr.view(torch_dtype)
+
+                try:
+                    setattr(mod, attr_name, attr)
+                except TypeError:
+                    # this means already have attr_name as a parameter, then
+                    # just assign this way
+                    mod.__dict__[attr_name] = attr
+
+        if is_method_forward:
+            # in this case, the self is already bound
+            return old_forward(*args, **kwargs)
+        return old_forward(self, *args, **kwargs)
 
     return _forward

--- a/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_autogptq.py
+++ b/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_autogptq.py
@@ -55,7 +55,10 @@ class AutoGPTQAccelerationPlugin(AccelerationPlugin):
         from auto_gptq.nn_modules.qlinear.qlinear_tritonv2 import QuantLinear #pylint: disable=import-outside-toplevel,import-error
 
         # Local
-        from .autogptq_utils import patch_forward_to_view_attributes_before_call #pylint: disable=import-outside-toplevel
+        from .autogptq_utils import ( #pylint: disable=import-outside-toplevel
+            patch_forward_to_view_attributes_before_call, 
+            PATCH_FOR_FSDP_TRITON_V2
+        )
 
         # Currently we allow only a quantized checkpoint to be loaded, we do not
         # implement the quantization process here.
@@ -145,9 +148,6 @@ class AutoGPTQAccelerationPlugin(AccelerationPlugin):
             world_size > 1
             and os.environ.get("ACCELERATE_USE_FSDP", "false").lower() == "true"
         ):
-            # these parameters are to be patched for triton v2
-            # consider making a map if patching more kernels
-            PATCH_FOR_FSDP_TRITON_V2 = ["qweight", "qzeros"]
 
             # patch all the QuantLinear base layers
             for mod in model.modules():

--- a/plugins/framework/src/fms_acceleration/framework.py
+++ b/plugins/framework/src/fms_acceleration/framework.py
@@ -179,11 +179,12 @@ class AccelerationFramework:
         self, model: torch.nn.Module = None, accelerator: Accelerator = None
     ):
         # show the initialized message
-        log_initialization_message(
-            {x for x, _ in self.active_plugins},
-            PLUGIN_REGISTRATIONS,
-            logging_func=logger.info,
-        )
+        if accelerator is not None and accelerator.is_main_process:
+            log_initialization_message(
+                {x for x, _ in self.active_plugins},
+                PLUGIN_REGISTRATIONS,
+                logging_func=logger.info,
+            )
 
         cbks = []
         for _, plugin in self.active_plugins:

--- a/scripts/benchmarks/scenarios.yaml
+++ b/scripts/benchmarks/scenarios.yaml
@@ -68,6 +68,7 @@ scenarios:
 
     -   name: accelerated-peft-gptq
         framework_config: 
+            - accelerated-peft-autogptq
             - accelerated-peft-autogptq-foak
         arguments:
             learning_rate: 2e-4


### PR DESCRIPTION
As https://github.com/foundation-model-stack/fms-acceleration/pull/15 mentions there is a casting issue when using GPTQ-LoRA and Fused ops. 

This issue occurs in fused ops because we bypass the base layer's forward, which we introduced a `reinterpret_cast` in the above mentioned issue:
- to resolve, we instead patch the fused ops functions directly. 
- we change `patch_forward_to_view_attributes_before_call` to allow us to patch multiple submodules, this is needed for fused ops because these fowards trigger on the attention module, not on the linear modules directly.